### PR TITLE
Bump org.apache.kafka:kafka-clients in /quickstart/java/producer

### DIFF
--- a/quickstart/java/producer/pom.xml
+++ b/quickstart/java/producer/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>2.3.0</version>
+      <version>2.6.3</version>
     </dependency>
     <!-- Jackson is now a provided dependency of kafka-clients -->
     <!-- https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients/2.6.0 -->


### PR DESCRIPTION
Bumps org.apache.kafka:kafka-clients from 2.3.0 to 2.6.3.

---
updated-dependencies:
- dependency-name: org.apache.kafka:kafka-clients dependency-type: direct:production ...